### PR TITLE
Fix env override for heart monitor

### DIFF
--- a/IoT-Simulation/devices/heart-monitor/simulator.py
+++ b/IoT-Simulation/devices/heart-monitor/simulator.py
@@ -6,9 +6,12 @@ import datetime
 from threading import Thread
 from math import sin, cos, pi
 import struct
+import os
 
 class HeartMonitor:
-    def __init__(self, device_id="HR_001"):
+    def __init__(self, device_id=None):
+        if device_id is None:
+            device_id = os.environ.get("DEVICE_ID", "HR_001")
         self.device_id = device_id
         self.manufacturer = "SimuMed"
         self.model = "CardioTech-2000"
@@ -199,7 +202,7 @@ class HeartMonitor:
                 pass
 
 if __name__ == "__main__":
-    device_id = "HR_001"  # Can be overridden by environment variable
+    device_id = os.environ.get("DEVICE_ID", "HR_001")
     simulator = HeartMonitor(device_id)
     try:
         simulator.run()


### PR DESCRIPTION
## Summary
- handle DEVICE_ID env var in heart monitor simulator

## Testing
- `python -m py_compile $(find . -name '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68615720855083249ef7a2f3267e8123