### PR TITLE
Check DEVICE_ID env var in heart monitor

### DIFF
--- a/IoT-Simulation/devices/heart-monitor/simulator.py
+++ b/IoT-Simulation/devices/heart-monitor/simulator.py
@@ -6,9 +6,12 @@ import datetime
 from threading import Thread
 from math import sin, cos, pi
 import struct
+import os
 
 class HeartMonitor:
-    def __init__(self, device_id="HR_001"):
+    def __init__(self, device_id=None):
+        if device_id is None:
+            device_id = os.environ.get("DEVICE_ID", "HR_001")
         self.device_id = device_id
         self.manufacturer = "SimuMed"
         self.model = "CardioTech-2000"
@@ -199,8 +202,7 @@ class HeartMonitor:
                 pass
 
 if __name__ == "__main__":
-    device_id = "HR_001"  # Can be overridden by environment variable
-    simulator = HeartMonitor(device_id)
+    simulator = HeartMonitor()
     try:
         simulator.run()
     except KeyboardInterrupt:


### PR DESCRIPTION
## Summary
- add `os` import
- read DEVICE_ID from environment in the HeartMonitor constructor
- rely on constructor's default when running as main

## Testing
- `python -m py_compile IoT-Simulation/devices/heart-monitor/simulator.py`

------
https://chatgpt.com/codex/tasks/task_e_68615bed31b88324a2517bac306e7ee9